### PR TITLE
Fix for CS1644 compilation errors on pre-2019.2 versions of unity

### DIFF
--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Control/Managers/InternalCSGModelManager.UpdateMeshes.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Control/Managers/InternalCSGModelManager.UpdateMeshes.cs
@@ -527,7 +527,12 @@ namespace RealtimeCSG
                                 renderSurfaceType == RenderSurfaceType.Collider ||
                                 renderSurfaceType == RenderSurfaceType.Trigger)
                             {
+#if !UNITY_2019_2_OR_NEWER
+                                GeneratedMeshInstance meshInstance;
+                                if (TryGetMeshInstance(meshContainer, model, model.Settings, __meshDescriptions[meshIndex], renderSurfaceType, out meshInstance))
+#else
                                 if (TryGetMeshInstance(meshContainer, model, model.Settings, __meshDescriptions[meshIndex], renderSurfaceType, out GeneratedMeshInstance meshInstance))
+#endif
                                 {
                                     if (meshInstance != null)
                                         __foundGeneratedMeshInstance.Add(meshInstance);
@@ -537,7 +542,12 @@ namespace RealtimeCSG
                             }
                             if (renderSurfaceType != RenderSurfaceType.Normal)
                             {
+#if !UNITY_2019_2_OR_NEWER
+                                HelperSurfaceDescription helperSurface;
+                                if (TryGetHelperSurfaceDescription(meshContainer, model, model.Settings, __meshDescriptions[meshIndex], renderSurfaceType, out helperSurface))
+#else
                                 if (TryGetHelperSurfaceDescription(meshContainer, model, model.Settings, __meshDescriptions[meshIndex], renderSurfaceType, out HelperSurfaceDescription helperSurface))
+#endif
                                 {
                                     if (helperSurface != null)
                                         __foundHelperSurfaces.Add(helperSurface);

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Runtime/Scripts/Components/GeneratedMeshInstance.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Runtime/Scripts/Components/GeneratedMeshInstance.cs
@@ -257,6 +257,18 @@ namespace InternalRealtimeCSG
         
         public void FindMissingSharedMesh()
         {
+#if !UNITY_2019_2_OR_NEWER
+            MeshCollider meshCollider;
+            MeshFilter meshFilter;
+            if (gameObject.TryGetComponent(out meshCollider))
+            {
+                SharedMesh = meshCollider.sharedMesh;
+            } else
+            if (gameObject.TryGetComponent(out meshFilter))
+            {
+                SharedMesh = meshFilter.sharedMesh;
+            }
+#else
             if (TryGetComponent(out MeshCollider meshCollider))
             {
                 SharedMesh = meshCollider.sharedMesh;
@@ -265,6 +277,7 @@ namespace InternalRealtimeCSG
             {
                 SharedMesh = meshFilter.sharedMesh;
             }
+#endif
         }
 #else
         void Awake() 

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Runtime/Scripts/Utility/GameObjectExtensions.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Runtime/Scripts/Utility/GameObjectExtensions.cs
@@ -3,14 +3,14 @@
 public static class GameObjectExtensions
 {
 #if !UNITY_2019_2_OR_NEWER
-    public static bool TryGetComponent<T>(this GameObject gameObject, T component) where T : UnityEngine.Component
+    public static bool TryGetComponent<T>(this GameObject gameObject, out T component) where T : UnityEngine.Component
     {
         component = gameObject.GetComponent<T>();
         if (!component) { component = null; return false; }
         return true;
     }
 
-    public static bool TryGetComponent<T>(this Component obj, T component) where T : UnityEngine.Component
+    public static bool TryGetComponent<T>(this Component obj, out T component) where T : UnityEngine.Component
     {
         component = obj.GetComponent<T>();
         if (!component) { component = null; return false; }


### PR DESCRIPTION
Small fix for some C# 6.0 features not supported on older versions of unity.