### PR TITLE
Adds Autorigidbody global preference/setting

### DIFF
--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/API/Components/Runtime/CSGModel.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/API/Components/Runtime/CSGModel.cs
@@ -47,7 +47,7 @@ namespace RealtimeCSG.Components
 	{
 		public const float CurrentVersion = 1.1f;
 
-        public static ModelSettingsFlags DefaultSettings = ((ModelSettingsFlags)UnityEngine.Rendering.ShadowCastingMode.On) | ModelSettingsFlags.PreserveUVs;
+        public static ModelSettingsFlags DefaultSettings = ((ModelSettingsFlags)UnityEngine.Rendering.ShadowCastingMode.On) | ModelSettingsFlags.PreserveUVs | ModelSettingsFlags.AutoUpdateRigidBody;
 
         /// <value>The version number of this instance of a <see cref="CSGModel" /></value>
         [HideInInspector] public float Version = CurrentVersion;

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Data/Settings/CSGSettings.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Data/Settings/CSGSettings.cs
@@ -274,6 +274,20 @@ namespace RealtimeCSG
             }
         }
         static public bool                  SnapNonCSGObjects				= true;
+        static public bool                  AutoRigidbody
+        {
+            get
+            {
+                return (CSGModel.DefaultSettings & ModelSettingsFlags.AutoUpdateRigidBody) == ModelSettingsFlags.AutoUpdateRigidBody;
+            }
+            set
+            {
+                if (value)
+                    CSGModel.DefaultSettings |= ModelSettingsFlags.AutoUpdateRigidBody;
+                else
+                    CSGModel.DefaultSettings &= ~ModelSettingsFlags.AutoUpdateRigidBody;
+            }
+        }
 
         static public Vector3				DefaultMoveOffset		= Vector3.zero;
         static public Vector3				DefaultRotateOffset		= Vector3.zero;
@@ -609,6 +623,7 @@ namespace RealtimeCSG
             HiddenSurfacesNotSelectable		= EditorPrefs.GetBool("HiddenSurfacesNotSelectable", true);
 //			HiddenSurfacesOrthoSelectable	= EditorPrefs.GetBool("HiddenSurfacesOrthoSelectable", true);
             ShowTooltips					= EditorPrefs.GetBool("ShowTooltips", true);
+            AutoRigidbody                   = EditorPrefs.GetBool("AutoRigidbody", (CSGModel.DefaultSettings & ModelSettingsFlags.AutoUpdateRigidBody) == ModelSettingsFlags.AutoUpdateRigidBody);
             DefaultPreserveUVs              = EditorPrefs.GetBool("DefaultPreserveUVs", (CSGModel.DefaultSettings & ModelSettingsFlags.PreserveUVs) == ModelSettingsFlags.PreserveUVs);
             SnapNonCSGObjects				= EditorPrefs.GetBool("SnapNonCSGObjects", true);
 
@@ -696,6 +711,7 @@ namespace RealtimeCSG
 //			EditorPrefs.SetBool("HiddenSurfacesOrthoSelectable", RealtimeCSG.CSGSettings.HiddenSurfacesOrthoSelectable);
 
             EditorPrefs.SetBool("ShowTooltips",				RealtimeCSG.CSGSettings.ShowTooltips);
+            EditorPrefs.SetBool("AutoRigidbody",            (CSGModel.DefaultSettings & ModelSettingsFlags.AutoUpdateRigidBody) == ModelSettingsFlags.AutoUpdateRigidBody);
             EditorPrefs.SetBool("DefaultPreserveUVs",       (CSGModel.DefaultSettings & ModelSettingsFlags.PreserveUVs) == ModelSettingsFlags.PreserveUVs);
             EditorPrefs.SetBool("SnapNonCSGObjects",		RealtimeCSG.CSGSettings.SnapNonCSGObjects);
 

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/PreferenceWindows/CSGOptions.PreferenceWindow.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/PreferenceWindows/CSGOptions.PreferenceWindow.cs
@@ -17,6 +17,7 @@ namespace RealtimeCSG
             {
                 CSGSettings.ShowTooltips		= EditorGUILayout.ToggleLeft("Show Tool-Tips",						CSGSettings.ShowTooltips);
                 CSGSettings.SnapNonCSGObjects	= EditorGUILayout.ToggleLeft("Snap Non-CSG Objects to the grid",	CSGSettings.SnapNonCSGObjects);
+                CSGSettings.AutoRigidbody       = EditorGUILayout.ToggleLeft("Auto add rigidbodies to models",      CSGSettings.AutoRigidbody);
                 CSGSettings.DefaultPreserveUVs  = EditorGUILayout.ToggleLeft("Preserve UVs (Default)",              CSGSettings.DefaultPreserveUVs);
                 EditorGUILayout.Space();
                 CSGSettings.MaxCircleSides		= EditorGUILayout.IntField("Max Circle Sides",  CSGSettings.MaxCircleSides);

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/PreferenceWindows/CSGOptions.PreferenceWindow.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/PreferenceWindows/CSGOptions.PreferenceWindow.cs
@@ -17,7 +17,7 @@ namespace RealtimeCSG
             {
                 CSGSettings.ShowTooltips		= EditorGUILayout.ToggleLeft("Show Tool-Tips",						CSGSettings.ShowTooltips);
                 CSGSettings.SnapNonCSGObjects	= EditorGUILayout.ToggleLeft("Snap Non-CSG Objects to the grid",	CSGSettings.SnapNonCSGObjects);
-                CSGSettings.AutoRigidbody       = EditorGUILayout.ToggleLeft("Auto add rigidbodies to models",      CSGSettings.AutoRigidbody);
+                CSGSettings.AutoRigidbody       = EditorGUILayout.ToggleLeft("Disable auto add rigidbodies",      CSGSettings.AutoRigidbody);
                 CSGSettings.DefaultPreserveUVs  = EditorGUILayout.ToggleLeft("Preserve UVs (Default)",              CSGSettings.DefaultPreserveUVs);
                 EditorGUILayout.Space();
                 CSGSettings.MaxCircleSides		= EditorGUILayout.IntField("Max Circle Sides",  CSGSettings.MaxCircleSides);


### PR DESCRIPTION
Adds a global preference that can be ticked on or off to change the default AutoRigidbody value for new models.

Currently it acts as a "Disables when ticked" box, but I would prefer it to function as "Enabled when ticked".

I tried changing the behavior but I'm not too familiar with the bitshifting going on and the overall architecture, and I couldn't get it working. I recommend making that change before accepting this PR