### PR TITLE
Fixes a reference error bug with play mode

### DIFF
--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Control/Managers/InternalCSGModelManager.DefaultModel.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Control/Managers/InternalCSGModelManager.DefaultModel.cs
@@ -88,7 +88,13 @@ namespace RealtimeCSG
 			bool inPrefabMode = false;
 			Transform prefabRootTransform = null;
 #if UNITY_2018_3_OR_NEWER
+
+#if UNITY_2021_2_OR_NEWER
+			var currentPrefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#else
 			var currentPrefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#endif
+
 			if (currentPrefabStage != null)
 			{
 				var prefabRoot = currentPrefabStage.prefabContentsRoot;

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Control/Managers/UpdateLoop.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Control/Managers/UpdateLoop.cs
@@ -11,52 +11,52 @@ using RealtimeCSG.Components;
 
 namespace RealtimeCSG
 {
-	[InitializeOnLoad]
-	internal sealed class UpdateLoop
-	{
-		[MenuItem("Edit/Realtime-CSG/Turn Realtime-CSG on or off %F3", false, 30)]
-		static void ToggleRealtimeCSG()
-		{
-			RealtimeCSG.CSGSettings.SetRealtimeCSGEnabled(!RealtimeCSG.CSGSettings.EnableRealtimeCSG);
-		}
+    [InitializeOnLoad]
+    internal sealed class UpdateLoop
+    {
+        [MenuItem("Edit/Realtime-CSG/Turn Realtime-CSG on or off %F3", false, 30)]
+        static void ToggleRealtimeCSG()
+        {
+            RealtimeCSG.CSGSettings.SetRealtimeCSGEnabled(!RealtimeCSG.CSGSettings.EnableRealtimeCSG);
+        }
 
-		public static bool IsActive() { return (editor != null && editor.initialized); }
+        public static bool IsActive() { return (editor != null && editor.initialized); }
 
 
-		static UpdateLoop editor = null;
-		static UpdateLoop()
-		{
-			if (editor != null)
-			{
-				editor.Shutdown();
-				editor = null;
-			}
-			editor = new UpdateLoop();
-			editor.Initialize();
-		}
+        static UpdateLoop editor = null;
+        static UpdateLoop()
+        {
+            if (editor != null)
+            {
+                editor.Shutdown();
+                editor = null;
+            }
+            editor = new UpdateLoop();
+            editor.Initialize();
+        }
 
-		bool initialized = false;
-		bool had_first_update = false;
+        bool initialized = false;
+        bool had_first_update = false;
 
-		void Initialize()
-		{
-			if (initialized)
-				return;
+        void Initialize()
+        {
+            if (initialized)
+                return;
 
-			CSGKeysPreferenceWindow.ReadKeys();
+            CSGKeysPreferenceWindow.ReadKeys();
 
-			initialized = true;
-			
-			CSGSceneManagerRedirector.Interface = new CSGSceneManagerInstance();
-			
-			Selection.selectionChanged					-= OnSelectionChanged;
-			Selection.selectionChanged					+= OnSelectionChanged;
+            initialized = true;
 
-			EditorApplication.update					-= OnFirstUpdate;
-			EditorApplication.update					+= OnFirstUpdate;
+            CSGSceneManagerRedirector.Interface = new CSGSceneManagerInstance();
+
+            Selection.selectionChanged -= OnSelectionChanged;
+            Selection.selectionChanged += OnSelectionChanged;
+
+            EditorApplication.update -= OnFirstUpdate;
+            EditorApplication.update += OnFirstUpdate;
 
 #if UNITY_2018_1_OR_NEWER
-			EditorApplication.hierarchyChanged	-= OnHierarchyWindowChanged;
+            EditorApplication.hierarchyChanged -= OnHierarchyWindowChanged;
             EditorApplication.hierarchyChanged += OnHierarchyWindowChanged;
 
 #else
@@ -65,15 +65,19 @@ namespace RealtimeCSG
 #endif
 
 #if UNITY_2018_3_OR_NEWER
-            UnityEditor.Experimental.SceneManagement.PrefabStage.prefabSaving += OnPrefabSaving;
+    #if UNITY_2021_2_OR_NEWER
+            UnityEditor.SceneManagement.PrefabStage.prefabSaving += OnPrefabSaving;
+    #else
+			UnityEditor.Experimental.SceneManagement.PrefabStage.prefabSaving += OnPrefabSaving;
+    #endif
 
 #endif
 
-            EditorApplication.hierarchyWindowItemOnGUI	-= HierarchyWindowItemGUI.OnHierarchyWindowItemOnGUI;
-			EditorApplication.hierarchyWindowItemOnGUI	+= HierarchyWindowItemGUI.OnHierarchyWindowItemOnGUI;
-			
-			UnityCompilerDefineManager.UpdateUnityDefines();
-		}
+            EditorApplication.hierarchyWindowItemOnGUI -= HierarchyWindowItemGUI.OnHierarchyWindowItemOnGUI;
+            EditorApplication.hierarchyWindowItemOnGUI += HierarchyWindowItemGUI.OnHierarchyWindowItemOnGUI;
+
+            UnityCompilerDefineManager.UpdateUnityDefines();
+        }
 
 #if UNITY_2018_3_OR_NEWER
         private void OnPrefabSaving(GameObject obj)
@@ -84,142 +88,142 @@ namespace RealtimeCSG
 
 
         void Shutdown(bool finalizing = false)
-		{
-			if (editor != this)
-				return;
+        {
+            if (editor != this)
+                return;
 
-			editor = null;
-			CSGSceneManagerRedirector.Interface = null;
-			if (!initialized)
-				return;
+            editor = null;
+            CSGSceneManagerRedirector.Interface = null;
+            if (!initialized)
+                return;
 
-			EditorApplication.update					-= OnFirstUpdate;
+            EditorApplication.update -= OnFirstUpdate;
 
 #if UNITY_2018_1_OR_NEWER
-			EditorApplication.hierarchyChanged	-= OnHierarchyWindowChanged;
+            EditorApplication.hierarchyChanged -= OnHierarchyWindowChanged;
 #else
 			EditorApplication.hierarchyWindowChanged	-= OnHierarchyWindowChanged;
 #endif
-			EditorApplication.hierarchyWindowItemOnGUI	-= HierarchyWindowItemGUI.OnHierarchyWindowItemOnGUI;
+            EditorApplication.hierarchyWindowItemOnGUI -= HierarchyWindowItemGUI.OnHierarchyWindowItemOnGUI;
 
 #if UNITY_2019_1_OR_NEWER
-			SceneView.duringSceneGui					-= SceneViewEventHandler.OnScene;
+            SceneView.duringSceneGui -= SceneViewEventHandler.OnScene;
 #else
 			SceneView.onSceneGUIDelegate				-= SceneViewEventHandler.OnScene;
 #endif
-			Undo.undoRedoPerformed						-= UndoRedoPerformed;
+            Undo.undoRedoPerformed -= UndoRedoPerformed;
 
-			initialized = false;
+            initialized = false;
 
-			// make sure the C++ side of things knows to clear the method pointers
-			// so that we don't accidentally use them while closing unity
-			NativeMethodBindings.ClearUnityMethods();
-			NativeMethodBindings.ClearExternalMethods();
+            // make sure the C++ side of things knows to clear the method pointers
+            // so that we don't accidentally use them while closing unity
+            NativeMethodBindings.ClearUnityMethods();
+            NativeMethodBindings.ClearExternalMethods();
 
-			if (!finalizing)
-				SceneToolRenderer.Cleanup();
-		}
+            if (!finalizing)
+                SceneToolRenderer.Cleanup();
+        }
 
-		static Scene currentScene;
-		internal static void UpdateOnSceneChange()
-		{
-			if (EditorApplication.isPlayingOrWillChangePlaymode)
-				return;
+        static Scene currentScene;
+        internal static void UpdateOnSceneChange()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+                return;
 
-			var activeScene = SceneManager.GetActiveScene();
-			if (currentScene != activeScene)
-			{
-				if (editor == null)
-					ResetUpdateRoutine();
+            var activeScene = SceneManager.GetActiveScene();
+            if (currentScene != activeScene)
+            {
+                if (editor == null)
+                    ResetUpdateRoutine();
 
-				editor.OnSceneUnloaded();
-				currentScene = activeScene;
-				InternalCSGModelManager.InitOnNewScene();
-			}
-		}
+                editor.OnSceneUnloaded();
+                currentScene = activeScene;
+                InternalCSGModelManager.InitOnNewScene();
+            }
+        }
 
-		void OnSceneUnloaded()
-		{
-			if (EditorApplication.isPlayingOrWillChangePlaymode)
-				return;
+        void OnSceneUnloaded()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+                return;
 
-			if (this.initialized)
-				this.Shutdown();
-			
-			MeshInstanceManager.Shutdown();
-			InternalCSGModelManager.Shutdown();
+            if (this.initialized)
+                this.Shutdown();
 
-			editor = new UpdateLoop();
-			editor.Initialize();
-		}
+            MeshInstanceManager.Shutdown();
+            InternalCSGModelManager.Shutdown();
 
-		public static void EnsureFirstUpdate()
-		{
-			if (editor == null)
-				return;
-			if (!editor.had_first_update)
-				editor.OnFirstUpdate();
-		}
+            editor = new UpdateLoop();
+            editor.Initialize();
+        }
 
-		void OnHierarchyWindowChanged()
-		{
-			if (EditorApplication.isPlayingOrWillChangePlaymode)
-				return;
+        public static void EnsureFirstUpdate()
+        {
+            if (editor == null)
+                return;
+            if (!editor.had_first_update)
+                editor.OnFirstUpdate();
+        }
 
-			SceneDragToolManager.UpdateDragAndDrop();
-			InternalCSGModelManager.UpdateHierarchy();
-		}  
+        void OnHierarchyWindowChanged()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+                return;
 
-		void UndoRedoPerformed()
-		{
-			InternalCSGModelManager.UndoRedoPerformed();
-		}
+            SceneDragToolManager.UpdateDragAndDrop();
+            InternalCSGModelManager.UpdateHierarchy();
+        }
 
-		// Delegate for generic updates
-		void OnFirstUpdate()
-		{
-			had_first_update = true;
-			EditorApplication.update -= OnFirstUpdate;
-			RealtimeCSG.CSGSettings.Reload();
-			
-			// register unity methods in the c++ code so that some unity functions
-			// (such as debug.log) can be called from within the c++ code.
-			NativeMethodBindings.RegisterUnityMethods();
+        void UndoRedoPerformed()
+        {
+            InternalCSGModelManager.UndoRedoPerformed();
+        }
 
-			// register dll methods so we can use them
-			NativeMethodBindings.RegisterExternalMethods();
-			
-			RunOnce();
-			//CreateSceneChangeDetector();
-		}
-		
-		void RunOnce()
-		{
-			if (EditorApplication.isPlayingOrWillChangePlaymode)
-			{
-				// when you start playing the game in the editor, it'll call 
-				// RunOnce before playing the game, but not after.
-				// so we need to wait until the game has stopped, after which we'll 
-				// run first update again.
-				EditorApplication.update -= OnWaitUntillStoppedPlaying;
-				EditorApplication.update += OnWaitUntillStoppedPlaying;
-				return;
-			}
+        // Delegate for generic updates
+        void OnFirstUpdate()
+        {
+            had_first_update = true;
+            EditorApplication.update -= OnFirstUpdate;
+            RealtimeCSG.CSGSettings.Reload();
+
+            // register unity methods in the c++ code so that some unity functions
+            // (such as debug.log) can be called from within the c++ code.
+            NativeMethodBindings.RegisterUnityMethods();
+
+            // register dll methods so we can use them
+            NativeMethodBindings.RegisterExternalMethods();
+
+            RunOnce();
+            //CreateSceneChangeDetector();
+        }
+
+        void RunOnce()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                // when you start playing the game in the editor, it'll call 
+                // RunOnce before playing the game, but not after.
+                // so we need to wait until the game has stopped, after which we'll 
+                // run first update again.
+                EditorApplication.update -= OnWaitUntillStoppedPlaying;
+                EditorApplication.update += OnWaitUntillStoppedPlaying;
+                return;
+            }
 
 #if UNITY_2019_1_OR_NEWER
-			SceneView.duringSceneGui		-= SceneViewEventHandler.OnScene;
-			SceneView.duringSceneGui		+= SceneViewEventHandler.OnScene;
+            SceneView.duringSceneGui -= SceneViewEventHandler.OnScene;
+            SceneView.duringSceneGui += SceneViewEventHandler.OnScene;
 #else
 			SceneView.onSceneGUIDelegate	-= SceneViewEventHandler.OnScene;
 			SceneView.onSceneGUIDelegate	+= SceneViewEventHandler.OnScene;
 #endif
-            Undo.undoRedoPerformed			-= UndoRedoPerformed;
-			Undo.undoRedoPerformed			+= UndoRedoPerformed;
-			
-//			InternalCSGModelManager.UpdateHierarchy();
-			
-			// but .. why?
-			/*
+            Undo.undoRedoPerformed -= UndoRedoPerformed;
+            Undo.undoRedoPerformed += UndoRedoPerformed;
+
+            //			InternalCSGModelManager.UpdateHierarchy();
+
+            // but .. why?
+            /*
 			var scene = SceneManager.GetActiveScene();	
 			var allGeneratedMeshes = SceneQueryUtility.GetAllComponentsInScene<GeneratedMeshes>(scene);
 			for (int i = 0; i < allGeneratedMeshes.Count; i++)
@@ -229,71 +233,71 @@ namespace RealtimeCSG
 			}
 			*/
 
-			// we use a co-routine for updates because EditorApplication.update
-			// works at a ridiculous rate and the co-routine is only fired in the
-			// editor when something has happened.
-			ResetUpdateRoutine();
-		}
+            // we use a co-routine for updates because EditorApplication.update
+            // works at a ridiculous rate and the co-routine is only fired in the
+            // editor when something has happened.
+            ResetUpdateRoutine();
+        }
 
-		void OnWaitUntillStoppedPlaying()
-		{
-			if (!EditorApplication.isPlaying)
-			{
-				EditorApplication.update -= OnWaitUntillStoppedPlaying;
+        void OnWaitUntillStoppedPlaying()
+        {
+            if (!EditorApplication.isPlaying)
+            {
+                EditorApplication.update -= OnWaitUntillStoppedPlaying;
 
-				EditorApplication.update -= OnFirstUpdate;	
-				EditorApplication.update += OnFirstUpdate;
-			}
-		}
-		
-		static void RunEditorUpdate()
-		{
-			if (!RealtimeCSG.CSGSettings.EnableRealtimeCSG)
-				return;
+                EditorApplication.update -= OnFirstUpdate;
+                EditorApplication.update += OnFirstUpdate;
+            }
+        }
 
-			if (EditorApplication.isPlayingOrWillChangePlaymode)
-				return;
+        static void RunEditorUpdate()
+        {
+            if (!RealtimeCSG.CSGSettings.EnableRealtimeCSG)
+                return;
 
-			UpdateLoop.UpdateOnSceneChange();
-		
-			try
-			{
-				if (!ColorSettings.isInitialized)
-					ColorSettings.Update();
-				InternalCSGModelManager.CheckForChanges(forceHierarchyUpdate: false);
-				TooltipUtility.CleanCache();
-			}
-			catch (Exception ex)
-			{
-				Debug.LogException(ex);
-			}
-		}
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+                return;
 
-		public static void ResetUpdateRoutine()
-		{
-			if (EditorApplication.isPlayingOrWillChangePlaymode)
-				return;
+            UpdateLoop.UpdateOnSceneChange();
 
-			if (editor != null &&
-				!editor.initialized)
-			{
-				editor = null;
-			}
-			if (editor == null)
-			{
-				editor = new UpdateLoop();
-				editor.Initialize();
-			}
+            try
+            {
+                if (!ColorSettings.isInitialized)
+                    ColorSettings.Update();
+                InternalCSGModelManager.CheckForChanges(forceHierarchyUpdate: false);
+                TooltipUtility.CleanCache();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
+        }
 
-			EditorApplication.update -= RunEditorUpdate;
-			EditorApplication.update += RunEditorUpdate;
-			InternalCSGModelManager.skipCheckForChanges = false;
-		}
+        public static void ResetUpdateRoutine()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+                return;
+
+            if (editor != null &&
+                !editor.initialized)
+            {
+                editor = null;
+            }
+            if (editor == null)
+            {
+                editor = new UpdateLoop();
+                editor.Initialize();
+            }
+
+            EditorApplication.update -= RunEditorUpdate;
+            EditorApplication.update += RunEditorUpdate;
+            InternalCSGModelManager.skipCheckForChanges = false;
+        }
 
 
-		static void OnSelectionChanged()
-		{
-			EditModeManager.UpdateSelection();
-		}
-	}
+        static void OnSelectionChanged()
+        {
+            EditModeManager.UpdateSelection();
+        }
+    }
 }

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Utility/PrefabUtility.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/Utility/PrefabUtility.cs
@@ -8,13 +8,13 @@ namespace RealtimeCSG
 {
     public sealed class CSGPrefabUtility
     {
-	    public static UnityEngine.Object GetCorrespondingObjectFromSource(UnityEngine.Object source)
-	    {
-    #if UNITY_2018_2_OR_NEWER
-		    return PrefabUtility.GetCorrespondingObjectFromSource(source);
-    #else
+        public static UnityEngine.Object GetCorrespondingObjectFromSource(UnityEngine.Object source)
+        {
+#if UNITY_2018_2_OR_NEWER
+            return PrefabUtility.GetCorrespondingObjectFromSource(source);
+#else
 		    return PrefabUtility.GetPrefabParent(source);
-    #endif
+#endif
         }
 
         public static bool IsPrefab(CSGModel model)
@@ -31,18 +31,18 @@ namespace RealtimeCSG
 
         public static bool AreInPrefabMode()
         {
-    #if UNITY_2018_3_OR_NEWER && UNITY_EDITOR
+#if UNITY_2018_3_OR_NEWER && UNITY_EDITOR
             var mainStage = StageUtility.GetMainStageHandle();
             var currentStageHandle = StageUtility.GetCurrentStageHandle();
             if (mainStage != currentStageHandle)
                 return true;
-    #endif
+#endif
             return false;
         }
 
         public static bool IsEditedInPrefabMode(CSGModel model)
         {
-    #if UNITY_2018_3_OR_NEWER && UNITY_EDITOR
+#if UNITY_2018_3_OR_NEWER && UNITY_EDITOR
             if (!model)
                 return false;
 
@@ -52,135 +52,139 @@ namespace RealtimeCSG
             var currentStageHandle = StageUtility.GetCurrentStageHandle();
             if (currentStageHandle.Contains(model.gameObject))
                 return true;
-    #endif
+#endif
             return false;
         }
 
         public static CSGNode[] GetNodesInPrefabMode()
         {
-    #if UNITY_2018_3_OR_NEWER && UNITY_EDITOR
+#if UNITY_2018_3_OR_NEWER && UNITY_EDITOR
             var mainStage = StageUtility.GetMainStageHandle();
             var currentStageHandle = StageUtility.GetCurrentStageHandle();
             if (mainStage != currentStageHandle)
                 return currentStageHandle.FindComponentsOfType<CSGNode>();
-    #endif
+#endif
             return null;
         }
 
         public static bool IsPrefabAssetOrInstance(GameObject gameObject)
-	    {
-    #if UNITY_2018_3_OR_NEWER
-		    var prefabAssetType		= PrefabUtility.GetPrefabAssetType(gameObject);
-		    var prefabInstanceType	= PrefabUtility.GetPrefabInstanceStatus(gameObject);
-		    if (prefabAssetType == PrefabAssetType.NotAPrefab &&
-			    prefabInstanceType == PrefabInstanceStatus.NotAPrefab)
-			    return false;
-		    return true;
-    #else
+        {
+#if UNITY_2018_3_OR_NEWER
+            var prefabAssetType = PrefabUtility.GetPrefabAssetType(gameObject);
+            var prefabInstanceType = PrefabUtility.GetPrefabInstanceStatus(gameObject);
+            if (prefabAssetType == PrefabAssetType.NotAPrefab &&
+                prefabInstanceType == PrefabInstanceStatus.NotAPrefab)
+                return false;
+            return true;
+#else
 		    var prefabType = PrefabUtility.GetPrefabType(gameObject);
 		    if (prefabType == PrefabType.None)
 			    return false;
 
 		    return true;
-    #endif
-	    }
-	
-	    public static bool IsPrefabAsset(GameObject gameObject)
-	    {
-    #if UNITY_2018_3_OR_NEWER
-		    var prefabInstanceType = PrefabUtility.GetPrefabInstanceStatus(gameObject);
-		    if (prefabInstanceType != PrefabInstanceStatus.NotAPrefab) 
-			    return false;
-		     
-		    var prefabType = PrefabUtility.GetPrefabAssetType(gameObject);
-		    return	prefabType != PrefabAssetType.NotAPrefab &&
-				    prefabType != PrefabAssetType.Model;
-    #else
+#endif
+        }
+
+        public static bool IsPrefabAsset(GameObject gameObject)
+        {
+#if UNITY_2018_3_OR_NEWER
+            var prefabInstanceType = PrefabUtility.GetPrefabInstanceStatus(gameObject);
+            if (prefabInstanceType != PrefabInstanceStatus.NotAPrefab)
+                return false;
+
+            var prefabType = PrefabUtility.GetPrefabAssetType(gameObject);
+            return prefabType != PrefabAssetType.NotAPrefab &&
+                    prefabType != PrefabAssetType.Model;
+#else
 		    var prefabType = PrefabUtility.GetPrefabType(gameObject);
 		    if (prefabType == PrefabType.None)
 			    return false;
 
 		    return (prefabType == PrefabType.Prefab ||
 				    prefabType == PrefabType.ModelPrefab);
-    #endif
-	    }
-	
-	    public static bool IsPrefabInstance(GameObject gameObject)
-	    {
-    #if UNITY_2018_3_OR_NEWER
+#endif
+        }
+
+        public static bool IsPrefabInstance(GameObject gameObject)
+        {
+#if UNITY_2018_3_OR_NEWER
             if (!PrefabUtility.IsPartOfAnyPrefab(gameObject))
                 return false;
             var prefabType = PrefabUtility.GetPrefabInstanceStatus(gameObject);
-		    return prefabType != PrefabInstanceStatus.NotAPrefab;
-    #else
+            return prefabType != PrefabInstanceStatus.NotAPrefab;
+#else
 		    var prefabType = PrefabUtility.GetPrefabType(gameObject);
 		    if (prefabType == PrefabType.None)
 			    return false;
 
 		    return (prefabType != PrefabType.Prefab &&
 				    prefabType != PrefabType.ModelPrefab);
-    #endif
-	    }
+#endif
+        }
 
         public static GameObject GetPrefabAsset(GameObject gameObject)
         {
-    #if UNITY_2018_3_OR_NEWER
+#if UNITY_2018_3_OR_NEWER
             if (AreInPrefabMode())
             {
+#if UNITY_2021_2_OR_NEWER
+                var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#else
                 var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+#endif
                 if (prefabStage.IsPartOfPrefabContents(gameObject))
-    #if UNITY_2020_1_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
                     return (GameObject)AssetDatabase.LoadMainAssetAtPath(prefabStage.assetPath);
-    #else
+#else
                     return (GameObject)AssetDatabase.LoadMainAssetAtPath(prefabStage.prefabAssetPath);
-    #endif
+#endif
             }
-    #endif
+#endif
 
             if (!IsPrefabInstance(gameObject))
                 return null;
 
-    #if UNITY_2018_3_OR_NEWER
+#if UNITY_2018_3_OR_NEWER
             return (GameObject)AssetDatabase.LoadMainAssetAtPath(PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(gameObject));
-    #else
+#else
 		    return (GameObject)PrefabUtility.GetPrefabParent(gameObject);
-    #endif
+#endif
         }
 
         public static GameObject GetOutermostPrefabInstanceRoot(GameObject gameObject)
-	    {
-		    if (!IsPrefabInstance(gameObject))
-			    return null;
-    #if UNITY_2018_3_OR_NEWER
-		    return PrefabUtility.GetOutermostPrefabInstanceRoot(gameObject);
-    #else
+        {
+            if (!IsPrefabInstance(gameObject))
+                return null;
+#if UNITY_2018_3_OR_NEWER
+            return PrefabUtility.GetOutermostPrefabInstanceRoot(gameObject);
+#else
 		    return PrefabUtility.FindPrefabRoot(gameObject);
-    #endif
-	    }
+#endif
+        }
 
-	    public static GameObject Instantiate(GameObject originalGameObject, bool copy = false)
-	    {
-    #if UNITY_2018_3_OR_NEWER
-		    var prefabInstanceType	= PrefabUtility.GetPrefabInstanceStatus(originalGameObject);
-		    if (prefabInstanceType != PrefabInstanceStatus.NotAPrefab && !copy)
-		    {
-			    var corrObj = GetCorrespondingObjectFromSource(originalGameObject);
-			    var obj = PrefabUtility.InstantiatePrefab(corrObj);
-			    var result = obj as GameObject;
-			    return result;
-		    }
+        public static GameObject Instantiate(GameObject originalGameObject, bool copy = false)
+        {
+#if UNITY_2018_3_OR_NEWER
+            var prefabInstanceType = PrefabUtility.GetPrefabInstanceStatus(originalGameObject);
+            if (prefabInstanceType != PrefabInstanceStatus.NotAPrefab && !copy)
+            {
+                var corrObj = GetCorrespondingObjectFromSource(originalGameObject);
+                var obj = PrefabUtility.InstantiatePrefab(corrObj);
+                var result = obj as GameObject;
+                return result;
+            }
 
-		    var prefabAssetType		= PrefabUtility.GetPrefabAssetType(originalGameObject);
-		    if (prefabAssetType != PrefabAssetType.NotAPrefab && !copy)
-		    {
-			    var obj = PrefabUtility.InstantiatePrefab(originalGameObject);
-			    var result = obj as GameObject;
-			    return result;
-		    }
+            var prefabAssetType = PrefabUtility.GetPrefabAssetType(originalGameObject);
+            if (prefabAssetType != PrefabAssetType.NotAPrefab && !copy)
+            {
+                var obj = PrefabUtility.InstantiatePrefab(originalGameObject);
+                var result = obj as GameObject;
+                return result;
+            }
 
-		    var inst = UnityEngine.Object.Instantiate<GameObject>(originalGameObject);
-		    return inst;
-    #else
+            var inst = UnityEngine.Object.Instantiate<GameObject>(originalGameObject);
+            return inst;
+#else
 		    var prefabType = PrefabUtility.GetPrefabType(originalGameObject);
 		    if (prefabType == PrefabType.None || copy)
 			    return UnityEngine.Object.Instantiate<GameObject>(originalGameObject);
@@ -192,8 +196,8 @@ namespace RealtimeCSG
 		    else
 			    // PrefabInstance
 			    return PrefabUtility.InstantiatePrefab(GetCorrespondingObjectFromSource(originalGameObject)) as GameObject;
-    #endif
-	    }
+#endif
+        }
 
         internal static bool IsPartOfAsset(Mesh sharedMesh)
         {

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/EditModeGUI/EditModeToolWindow.Editor.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/EditModeGUI/EditModeToolWindow.Editor.cs
@@ -10,7 +10,10 @@ public class EditModeToolWindowEditor : Editor
 	public override void OnInspectorGUI()
 	{
 		if (EditorApplication.isPlayingOrWillChangePlaymode)
+		{
+			Selection.activeObject = null;
 			return;
+		}
 		RealtimeCSG.EditModeSelectionGUI.OnInspectorGUI(this, this.targets);
 	}
 }

--- a/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/SceneViewBottomBarGUI/SceneViewBottomBar.GUI.cs
+++ b/RealtimeCSG/Assets/Plugins/RealtimeCSG/Editor/Scripts/View/GUI/SceneViewBottomBarGUI/SceneViewBottomBar.GUI.cs
@@ -24,8 +24,13 @@ namespace RealtimeCSG
 				Rect bottomBarRect;
 				if (haveOffset)
 				{
+#if UNITY_2021_2_OR_NEWER
+					bottomBarRect = new Rect(0, height - (CSG_GUIStyleUtility.BottomToolBarHeight + 27),
+						  width, CSG_GUIStyleUtility.BottomToolBarHeight);
+#else
 					bottomBarRect = new Rect(0, height - (CSG_GUIStyleUtility.BottomToolBarHeight + 18), 
 											  width, CSG_GUIStyleUtility.BottomToolBarHeight);
+#endif
 				} else
 					bottomBarRect = new Rect(0, height - (CSG_GUIStyleUtility.BottomToolBarHeight + 1), width, CSG_GUIStyleUtility.BottomToolBarHeight);
 
@@ -97,7 +102,7 @@ namespace RealtimeCSG
 				currentRect.x		= layoutX;
 				layoutX += currentRect.width;
 
-				#region "Grid" button
+#region "Grid" button
 				if (showGrid)
 				{
 					showGrid = GUI.Toggle(currentRect, showGrid, skin.gridIconOn, EditorStyles.toolbarButton);
@@ -107,7 +112,7 @@ namespace RealtimeCSG
 				}
 				//(x:6.00, y:0.00, width:27.00, height:18.00)
 				TooltipUtility.SetToolTip(showGridTooltip, currentRect);
-				#endregion
+#endregion
 
 				if (viewWidth >= 800)
 					layoutX += 6; //(x:33.00, y:0.00, width:6.00, height:6.00)
@@ -117,7 +122,7 @@ namespace RealtimeCSG
 				if (lockAxisX)
 					GUI.backgroundColor = lockedBackgroundColor;
 
-				#region "X" lock button
+#region "X" lock button
 				currentRect.width	= 17;
 				currentRect.y		= 0;
 				currentRect.height	= layoutHeight - currentRect.y;
@@ -132,9 +137,9 @@ namespace RealtimeCSG
 				else
 					TooltipUtility.SetToolTip(xTooltipOff, currentRect);
 				GUI.backgroundColor = prevBackgroundColor;
-				#endregion
+#endregion
 												
-				#region "Y" lock button
+#region "Y" lock button
 				currentRect.x		= layoutX;
 				layoutX += currentRect.width;
 
@@ -147,9 +152,9 @@ namespace RealtimeCSG
 				else
 					TooltipUtility.SetToolTip(yTooltipOff, currentRect);
 				GUI.backgroundColor = prevBackgroundColor;
-				#endregion
+#endregion
 						
-				#region "Z" lock button
+#region "Z" lock button
 				currentRect.x		= layoutX;
 				layoutX += currentRect.width;
 
@@ -162,14 +167,14 @@ namespace RealtimeCSG
 				else
 					TooltipUtility.SetToolTip(zTooltipOff, currentRect);
 				GUI.backgroundColor = prevBackgroundColor;
-				#endregion
+#endregion
 			}
 			modified = GUI.changed || modified;
 
 			if (viewWidth >= 800)
 				layoutX += 6; // (x:91.00, y:0.00, width:6.00, height:6.00)
 				
-			#region "SnapMode" button
+#region "SnapMode" button
 			GUI.changed = false;
 			{
 				currentRect.width	= 27;
@@ -219,13 +224,13 @@ namespace RealtimeCSG
                 }
             }
             modified = GUI.changed || modified;
-            #endregion
+#endregion
 				
 			if (viewWidth >= 460)
 			{
 				if (snapMode != SnapMode.None)
 				{
-					#region "Position" label
+#region "Position" label
 					if (viewWidth >= 500)
 					{ 
 						if (viewWidth >= 865)
@@ -256,11 +261,11 @@ namespace RealtimeCSG
 							TooltipUtility.SetToolTip(positionTooltip, currentRect);
 						}
 					}
-					#endregion
+#endregion
 							
 					layoutX += 2;
 
-					#region "Position" field
+#region "Position" field
 					if (uniformGrid || viewWidth < 515)
 					{
 						EditorGUI.showMixedValue = !(moveSnapVector.x == moveSnapVector.y && moveSnapVector.x == moveSnapVector.z);
@@ -316,11 +321,11 @@ namespace RealtimeCSG
 						}
 						modified = GUI.changed || modified;
 					}
-					#endregion
+#endregion
 
 					layoutX++;
 
-					#region "Position" Unit
+#region "Position" Unit
 					DistanceUnit nextUnit = Units.CycleToNextUnit(distanceUnit);
 					GUIContent   unitText = Units.GetUnitGUIContent(distanceUnit);
 						
@@ -336,11 +341,11 @@ namespace RealtimeCSG
 						distanceUnit = nextUnit;
 						modified = true;
 					}
-					#endregion
+#endregion
 
 					layoutX += 2;
 
-					#region "Position" +/-
+#region "Position" +/-
 					if (viewWidth >= 700)
 					{
 						currentRect.width	= 19;
@@ -365,11 +370,11 @@ namespace RealtimeCSG
 						//(x:429.00, y:2.00, width:17.00, height:15.00)
 						TooltipUtility.SetToolTip(positionMinnusTooltip, currentRect);
 					}
-					#endregion
+#endregion
 
 					layoutX += 2;
 
-					#region "Angle" label
+#region "Angle" label
 					if (viewWidth >= 750)
 					{
 						if (viewWidth >= 865)
@@ -397,11 +402,11 @@ namespace RealtimeCSG
 						}
 						TooltipUtility.SetToolTip(angleTooltip, currentRect);
 					}
-					#endregion
+#endregion
 						
 					layoutX += 2;
 
-					#region "Angle" field
+#region "Angle" field
 					GUI.changed = false;
 					{
 						currentRect.width	= 70;
@@ -417,11 +422,11 @@ namespace RealtimeCSG
 							TooltipUtility.SetToolTip(angleTooltip, currentRect);
 					}
 					modified = GUI.changed || modified;
-					#endregion
+#endregion
 
 					layoutX++;
 
-					#region "Angle" Unit
+#region "Angle" Unit
 					if (viewWidth >= 370)
 					{
 						currentRect.width	= 14;
@@ -433,11 +438,11 @@ namespace RealtimeCSG
 							
 						GUI.Label(currentRect, angleUnitLabel, miniTextStyle);
 					}
-					#endregion
+#endregion
 						
 					layoutX += 2;
 
-					#region "Angle" +/-
+#region "Angle" +/-
 					if (viewWidth >= 700)
 					{
 						currentRect.width	= 19;
@@ -463,11 +468,11 @@ namespace RealtimeCSG
 						//(x:592.00, y:2.00, width:17.00, height:15.00)
 						TooltipUtility.SetToolTip(angleMinnusTooltip, currentRect);
 					}
-					#endregion
+#endregion
 
 					layoutX += 2;
 
-					#region "Scale" label
+#region "Scale" label
 					if (viewWidth >= 750)
 					{
 						if (viewWidth >= 865)
@@ -495,11 +500,11 @@ namespace RealtimeCSG
 						}
 						TooltipUtility.SetToolTip(scaleTooltip, currentRect);
 					}
-					#endregion
+#endregion
 						
 					layoutX += 2;
 
-					#region "Scale" field
+#region "Scale" field
 					GUI.changed = false;
 					{
 						currentRect.width	= 70;
@@ -515,11 +520,11 @@ namespace RealtimeCSG
 							TooltipUtility.SetToolTip(scaleTooltip, currentRect);
 					}
 					modified = GUI.changed || modified;
-					#endregion
+#endregion
 
 					layoutX ++;
 						
-					#region "Scale" Unit
+#region "Scale" Unit
 					if (viewWidth >= 370)
 					{
 						currentRect.width	= 15;
@@ -532,11 +537,11 @@ namespace RealtimeCSG
 						GUI.Label(currentRect, scaleUnitLabel, miniTextStyle);
 						//(x:722.00, y:2.00, width:15.00, height:16.00)
 					}
-					#endregion
+#endregion
 						
 					layoutX += 2;
 
-					#region "Scale" +/-
+#region "Scale" +/-
 					if (viewWidth >= 700)
 					{
 						currentRect.width	= 19;
@@ -562,7 +567,7 @@ namespace RealtimeCSG
 						//(x:760.00, y:2.00, width:17.00, height:15.00)
 						TooltipUtility.SetToolTip(scaleMinnusTooltip, currentRect);
 					}
-					#endregion
+#endregion
 				}
 			}
 
@@ -572,7 +577,7 @@ namespace RealtimeCSG
 			layoutX = viewWidth;
 
 				
-			#region "Rebuild"
+#region "Rebuild"
 			currentRect.width	= 27;
 			currentRect.y		= 0;
 			currentRect.height	= layoutHeight - currentRect.y; 
@@ -626,12 +631,12 @@ namespace RealtimeCSG
 			}
 			//(x:1442.00, y:0.00, width:27.00, height:18.00)
 			TooltipUtility.SetToolTip(rebuildTooltip, currentRect);
-			#endregion
+#endregion
 
 			if (viewWidth >= 800)
 				layoutX -= 6; //(x:1436.00, y:0.00, width:6.00, height:6.00)
 
-			#region "Helper Surface Flags" Mask
+#region "Helper Surface Flags" Mask
 			if (viewWidth >= 250)
 			{
 				GUI.changed = false;
@@ -658,9 +663,9 @@ namespace RealtimeCSG
 					modified = true;
 				}
 			}
-			#endregion
+#endregion
 
-			#region "Show wireframe" button
+#region "Show wireframe" button
 			GUI.changed = false;
 			currentRect.width	= 26;
 			currentRect.y		= 0;
@@ -684,13 +689,13 @@ namespace RealtimeCSG
 				wireframeModified = true;
 				modified = true;
 			}
-			#endregion
+#endregion
 
 
 
 
 
-			#region Capture mouse clicks in empty space
+#region Capture mouse clicks in empty space
 			var mousePoint  = Event.current.mousePosition;
 			int controlID = GUIUtility.GetControlID(BottomBarEditorOverlayHash, FocusType.Passive, barSize);
 			switch (Event.current.GetTypeForControl(controlID))
@@ -701,11 +706,11 @@ namespace RealtimeCSG
 				case EventType.MouseDrag:	{ if (GUIUtility.hotControl == controlID) { Event.current.Use(); } break; }
 				case EventType.ScrollWheel: { if (barSize.Contains(mousePoint)) { Event.current.Use(); } break; }
 			}
-			#endregion
+#endregion
 
 
 
-			#region Store modified values
+#region Store modified values
 			rotationSnap = Mathf.Max(1.0f, Mathf.Abs((360 + (rotationSnap % 360))) % 360);
 			moveSnapVector.x = Mathf.Max(1.0f / 1024.0f, moveSnapVector.x);
 			moveSnapVector.y = Mathf.Max(1.0f / 1024.0f, moveSnapVector.y);
@@ -743,7 +748,7 @@ namespace RealtimeCSG
 				RealtimeCSG.CSGSettings.Save();
 				CSG_EditorGUIUtility.RepaintAll();
 			}
-			#endregion
+#endregion
 		}
 		
 	}


### PR DESCRIPTION
- Have a selected brush
- Hit play
- After getting out of play mode, the tool throw a `NullReferenceException` inside `RealtimeCSG.EditModeSelectionGUI.OnInspectorGUI`

Tested on Unity 2019.3 and 2021.1