### PR TITLE
Compatibility fix for 2019.4.40f1

### DIFF
--- a/Plugins/Editor/Scripts/Control/Managers/InternalCSGModelManager.Lifetime.cs
+++ b/Plugins/Editor/Scripts/Control/Managers/InternalCSGModelManager.Lifetime.cs
@@ -163,57 +163,57 @@ namespace RealtimeCSG
 			if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles)
 				return;
 
-			static bool ensureExternalMethodsPopulated()
-			{
-				if (External == null ||
-					External.ResetCSG == null)
-				{
-					NativeMethodBindings.RegisterUnityMethods();
-					NativeMethodBindings.RegisterExternalMethods();
-				}
-
-				if (External == null)
-				{
-					Debug.LogError("RealtimeCSG: Cannot rebuild meshes for some reason. External modules not loaded. Please save meshes into the Scene.");
-					return false;
-				}
-
-				return true;
-			}
-
-			static void rebuildMeshes()
-            {
-				if (!ensureExternalMethodsPopulated())
-					return;
-
-				RealtimeCSG.CSGModelManager.AllowInEditorPlayMode = true;
-				InternalCSGModelManager.Shutdown();
-				DoForcedMeshUpdate();
-				InternalCSGModelManager.CheckForChanges(false);
-				RealtimeCSG.CSGModelManager.AllowInEditorPlayMode = false;
-			}
-
-			static void sceneLoaded(UnityEngine.SceneManagement.Scene scene, UnityEngine.SceneManagement.LoadSceneMode mode)
-			{
-				rebuildMeshes();
-			}
-
-			static void onPlayModeChange(PlayModeStateChange playMode)
-			{
-				if (playMode == PlayModeStateChange.EnteredEditMode)
-				{
-					UnityEngine.SceneManagement.SceneManager.sceneLoaded -= sceneLoaded;
-					EditorApplication.playModeStateChanged -= onPlayModeChange;
-
-					rebuildMeshes();
-				}
-			}
-
 			if (!ensureExternalMethodsPopulated())
 				return;
 
 			EditorApplication.playModeStateChanged += onPlayModeChange;
 			UnityEngine.SceneManagement.SceneManager.sceneLoaded += sceneLoaded;
+		}
+
+		static bool ensureExternalMethodsPopulated()
+		{
+			if (External == null ||
+			    External.ResetCSG == null)
+			{
+				NativeMethodBindings.RegisterUnityMethods();
+				NativeMethodBindings.RegisterExternalMethods();
+			}
+
+			if (External == null)
+			{
+				Debug.LogError("RealtimeCSG: Cannot rebuild meshes for some reason. External modules not loaded. Please save meshes into the Scene.");
+				return false;
+			}
+
+			return true;
+		}
+
+		static void rebuildMeshes()
+		{
+			if (!ensureExternalMethodsPopulated())
+				return;
+
+			RealtimeCSG.CSGModelManager.AllowInEditorPlayMode = true;
+			InternalCSGModelManager.Shutdown();
+			DoForcedMeshUpdate();
+			InternalCSGModelManager.CheckForChanges(false);
+			RealtimeCSG.CSGModelManager.AllowInEditorPlayMode = false;
+		}
+
+		static void sceneLoaded(UnityEngine.SceneManagement.Scene scene, UnityEngine.SceneManagement.LoadSceneMode mode)
+		{
+			rebuildMeshes();
+		}
+
+		static void onPlayModeChange(PlayModeStateChange playMode)
+		{
+			if (playMode == PlayModeStateChange.EnteredEditMode)
+			{
+				UnityEngine.SceneManagement.SceneManager.sceneLoaded -= sceneLoaded;
+				EditorApplication.playModeStateChanged -= onPlayModeChange;
+
+				rebuildMeshes();
+			}
 		}
 #endif
 	}

--- a/Plugins/Editor/Scripts/Control/Managers/InternalCSGModelManager.UpdateMeshes.cs
+++ b/Plugins/Editor/Scripts/Control/Managers/InternalCSGModelManager.UpdateMeshes.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using InternalRealtimeCSG;
 using RealtimeCSG.Foundation;
 using RealtimeCSG.Components;
+using UnityEngine.SceneManagement;
 
 namespace RealtimeCSG
 {
@@ -598,7 +599,19 @@ namespace RealtimeCSG
 		[MenuItem("Edit/Realtime-CSG/Destroy All Helper Surface Meshes In Scene")]
 		public static void DestroyAllHelperSurfaceCSGMeshes()
 		{
-			var allMeshesInScene = UnityEngine.Object.FindObjectsOfType<Mesh>(true);
+			var allMeshesInScene = new List<Mesh>();
+			for(int i = 0; i< SceneManager.sceneCount; i++)
+			{
+				var s = SceneManager.GetSceneAt(i);
+				if (s.isLoaded == false)
+					continue;
+				
+				foreach (var go in s.GetRootGameObjects())
+				{
+					foreach (var filter in go.GetComponentsInChildren<MeshFilter>(true))
+						allMeshesInScene.Add(filter.sharedMesh);
+				}
+			}
 
 			// regex matches all possible names for the helper surfaces that we can generate
 			var nameMatch = new System.Text.RegularExpressions.Regex(


### PR DESCRIPTION
2019.4.40f1doesn't support static local functions, nor inactive optional argument for `UnityEngine.Object.FindObjectsOfType`.
I'm not sure what helper surfaces are, so not even sure that my change would work in this context - let me know.

Small note, there's a ton of mixed whitespace in files, we may want to do something about that.
<img src="https://user-images.githubusercontent.com/5742236/206207902-42d4f436-73c7-4120-b479-8dee8aee67ef.png" width="200" />
