### PR TITLE
Crack stitching

### DIFF
--- a/Plugins/API/Components/Runtime/CSGModel.cs
+++ b/Plugins/API/Components/Runtime/CSGModel.cs
@@ -20,6 +20,7 @@ namespace RealtimeCSG.Components
 		StitchLightmapSeams		= 4096,
 		IgnoreNormals			= 8192,
 		TwoSidedShadows			= 16384,
+		AutoStitchCracks        = 32768
 	}
 
 	[Serializable]
@@ -61,6 +62,7 @@ namespace RealtimeCSG.Components
 		public bool	NeedAutoUpdateRigidBody	{ get { return (Settings & ModelSettingsFlags.AutoUpdateRigidBody) == (ModelSettingsFlags)0; } }
 		public bool	PreserveUVs         	{ get { return (Settings & ModelSettingsFlags.PreserveUVs) != (ModelSettingsFlags)0; } }
 		public bool StitchLightmapSeams		{ get { return (Settings & ModelSettingsFlags.StitchLightmapSeams) != (ModelSettingsFlags)0; } }		
+		public bool	AutoStitchCracks       	{ get { return (Settings & ModelSettingsFlags.AutoStitchCracks) != (ModelSettingsFlags)0; } }		
 		public bool	AutoRebuildUVs         	{ get { return (Settings & ModelSettingsFlags.AutoRebuildUVs) != (ModelSettingsFlags)0; } }
 		public bool	IgnoreNormals  			{ get { return (Settings & ModelSettingsFlags.IgnoreNormals) != (ModelSettingsFlags)0; } }
 

--- a/Plugins/Editor/Scripts/Control/Helpers/CracksStitching.cs
+++ b/Plugins/Editor/Scripts/Control/Helpers/CracksStitching.cs
@@ -1,0 +1,514 @@
+﻿// I know what I'm doing when comparing floats.
+// ReSharper disable CompareOfFloatsByEqualityOperator
+
+// Debug purposes, provides ability to step through the procedure, to inspect and visualize data between each steps
+//#define YIELD_SUBSTEPS
+
+namespace RealtimeCSG
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using UnityEditor;
+    using UnityEngine;
+    using static System.Math;
+    using Vector3 = UnityEngine.Vector3;
+
+    public static class CracksStitching
+    {
+        /// <summary>
+        /// Stitch cracks and small holes in meshes, this can take a significant amount of time depending on the mesh.
+        /// </summary>
+        /// <param name="mesh"> The mesh </param>
+        /// <param name="debug"> An object which will receive debug information </param>
+        /// <param name="maxDist">The maximum distance to cover when stitching cracks, larger than this will not be stitched</param>
+        public static void Solve(Mesh mesh, ISolverDebugProvider debug = null, float maxDist = 0.05f)
+        {
+            var subMeshes = new List<int>[mesh.subMeshCount];
+            for (int i = 0; i < mesh.subMeshCount; i++)
+                subMeshes[i] = mesh.GetTriangles(i).ToList();
+
+            foreach (var o in SolveRaw(mesh.vertices, mesh.triangles, subMeshes, debug, maxDist)){ }
+
+            var totalIndices = 0;
+            foreach (var list in subMeshes)
+                totalIndices += list.Count;
+            
+            if(totalIndices > ushort.MaxValue)
+                mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+
+            for (int i = 0; i < subMeshes.Length; i++)
+                mesh.SetTriangles(subMeshes[i], i);
+        }
+
+        public static void SolveAsync(Mesh mesh, ISolverDebugProvider debug, CancellationToken pCancellationToken, Action onFinished, float maxDist = 0.05f)
+        {
+            // Need to spawn a new class; mesh is not thread safe, we have to manipulate it after the async logic ran,
+            //   to that end we're relying on the editor update callback, but inline delegates cannot remove
+            //   themselves from a callback -> using class methods to work around this.
+            new AsyncJob().Solve(mesh, debug, pCancellationToken, onFinished, maxDist);
+        }
+
+        /// <summary>
+        /// Stitch cracks and small holes in meshes, this can take a significant amount of time depending on the mesh.
+        /// </summary>
+        /// <param name="vertices">All vertices of the mesh</param>
+        /// <param name="tris">All geometry indices of the mesh</param>
+        /// <param name="subMeshes">Submeshes geometry indices</param>
+        /// <param name="debug"> An object which will receive debug information </param>
+        /// <param name="maxDist"> The maximum distance to cover when stitching cracks, larger than this will not be stitched </param>
+        /// <returns> Yield while solving if the preprocessor has been enabled, otherwise returns empty </returns>
+        public static IEnumerable SolveRaw(Vector3[] vertices, int[] tris, List<int>[] subMeshes, ISolverDebugProvider debug, float maxDist = 0.05f)
+        {
+            // Merging duplicate vertices to ignore material-specific topology
+            Merge(vertices, out var newVertices, ref tris);
+            var nativeVertices = vertices;
+            vertices = newVertices;
+
+            var allEdges = new HashSet<EdgeId>();
+            var sharedEdges = new HashSet<EdgeId>();
+            
+            // We're thinking of cracks as edges that do not have multiple triangles 
+            for (int i = 0; i < tris.Length; i+=3)
+            {
+                int x = tris[i], y = tris[i + 1], z = tris[i + 2];
+                
+                var edgeA = new EdgeId(x, y);
+                var edgeB = new EdgeId(y, z);
+                var edgeC = new EdgeId(z, x);
+                
+                if (allEdges.Add(edgeA) == false)
+                    sharedEdges.Add(edgeA);
+                if(allEdges.Add(edgeB) == false)
+                    sharedEdges.Add(edgeB);
+                if(allEdges.Add(edgeC) == false)
+                    sharedEdges.Add(edgeC);
+            }
+            
+            // Only keep edges which do not share multiple triangles
+            var leftToSolve = new HashSet<EdgeId>(allEdges);
+            foreach (var edge in sharedEdges)
+                leftToSolve.Remove(edge);
+
+            var trianglesToAdd = new List<(int a, int b, int c)>();
+            var workingData = new WorkingData(trianglesToAdd, allEdges, leftToSolve, vertices);
+            
+            debug?.HookIntoWorkingData(workingData);
+
+            while (leftToSolve.Count > 0)
+            {
+                // Take one random edge from the hashset
+                EdgeId thisEdge;
+                using (var e = leftToSolve.GetEnumerator())
+                {
+                    e.MoveNext();
+                    thisEdge = e.Current;
+                }
+
+                if (ReturnBestMatchFor(ref thisEdge, ref workingData, out var bestMatch) == false || bestMatch.dist > maxDist)
+                {
+                    if(bestMatch.dist <= maxDist)
+                        throw new InvalidOperationException($"Stray edge ({thisEdge}) could not be solved for");
+                    
+                    debug?.LogWarning($"For edge {thisEdge}, closest match ({bestMatch.edge}) did not satisfy {nameof(maxDist)} constraint {bestMatch.dist}/{maxDist}");
+                    leftToSolve.Remove(thisEdge);
+                    continue;
+                }
+
+                // Found a best match for thisEdge but let's check that they are both best matches for each other
+                int swapCount = 0;
+                do
+                {
+                    ReturnBestMatchFor(ref bestMatch.edge, ref workingData, out var otherBestMatch);
+                    if (otherBestMatch.dist > maxDist)
+                    {
+                        debug?.LogWarning($"For edge {bestMatch.edge}, closest match ({otherBestMatch.edge}) did not satisfy {nameof(maxDist)} constraint {otherBestMatch.dist}/{maxDist}");
+                        leftToSolve.Remove(bestMatch.edge);
+                        break;
+                    }
+
+                    if (otherBestMatch.edge == thisEdge || swapCount > 10)
+                    {
+                        if (swapCount > 10)
+                        {
+                            // swapCount prevents very unlikely infinite loop with weird edge topology in
+                            // cases where X's best match is Y but Y's is Z which itself is X
+                            debug?.LogWarning($"Sub par match for {thisEdge} -> {otherBestMatch.edge}");
+                        }
+
+                        // Both edges are each other's best match
+                        leftToSolve.Remove(thisEdge);
+                        leftToSolve.Remove(bestMatch.edge);
+                        
+                        int index = trianglesToAdd.Count;
+                        CreateTriangles(ref workingData, ref thisEdge, ref bestMatch.edge);
+                        debug?.Log($"{thisEdge} -> {bestMatch.edge}: {trianglesToAdd[index]} {(trianglesToAdd.Count - index > 1 ? trianglesToAdd[index+1].ToString() : "")}");
+                        #if YIELD_SUBSTEPS
+                        yield return null;
+                        #endif
+                        break;
+                    }
+                    else
+                    {
+                        // They don't match, try to see if this new best match matches each other instead
+                        thisEdge = bestMatch.edge;
+                        bestMatch = otherBestMatch;
+                        swapCount++;
+                        #if YIELD_SUBSTEPS
+                        yield return null;
+                        #endif
+                        continue;
+                    }
+                } while (true);
+            }
+
+            var posToSubMesh = new Dictionary<Vector3, (int submesh, int vertIndex)>();
+            for (int subMeshIndex = 0; subMeshIndex < subMeshes.Length; subMeshIndex++)
+            {
+                var subMesh = subMeshes[subMeshIndex];
+                for (int i = 0; i < subMesh.Count; i++)
+                {
+                    var subMeshVertIndex = subMesh[i];
+                    var pos = nativeVertices[subMeshVertIndex];
+                    // Multiple assignment on the same key would matter
+                    // only for large holes next to multiple materials,
+                    // we do not expect cracks to be large enough to warrant solving for this.
+                    posToSubMesh[pos] = (subMeshIndex, subMeshVertIndex);
+                }
+            }
+
+            foreach (var (x, y, z) in trianglesToAdd)
+            {
+                var (subMeshIndex, mappingA) = posToSubMesh[vertices[x]];
+                var (           _, mappingB) = posToSubMesh[vertices[y]];
+                var (           _, mappingC) = posToSubMesh[vertices[z]];
+                
+                // Effectively randomly picking subMesh, i.e.: material, those triangles will be assigned to, see comment above
+                var indices = subMeshes[subMeshIndex];
+                
+                // Not sure yet how to properly solve winding order, add both sides for now
+                indices.Add(mappingA);
+                indices.Add(mappingB);
+                indices.Add(mappingC);
+                indices.Add(mappingC);
+                indices.Add(mappingB);
+                indices.Add(mappingA);
+            }
+            
+            #if !YIELD_SUBSTEPS
+                return Array.Empty<System.Object>();
+            #endif
+        }
+
+        /// <summary> Duplicate positions are stripped and indices are remapped appropriately </summary>
+        static void Merge(Vector3[] positions, out Vector3[] outPos, ref int[] indices)
+        {
+            var newPos = new List<Vector3>();
+            var posToIndex = new Dictionary<Vector3, int>();
+            for (int i = 0; i < indices.Length; i++)
+            {
+                var oldIndex = indices[i];
+                var pos = positions[oldIndex];
+                if (posToIndex.TryGetValue(pos, out var newIndex) == false)
+                {
+                    newIndex = newPos.Count;
+                    newPos.Add(pos);
+                    posToIndex.Add(pos, newIndex);
+                }
+
+                indices[i] = newIndex;
+            }
+
+            outPos = newPos.ToArray();
+        }
+
+        /// <summary> Create bridge between the given edges, append those new triangles and edges to working data </summary>
+        static void CreateTriangles(ref WorkingData data, ref EdgeId edgeAB, ref EdgeId edgeXY)
+        {
+            (int a, int b) = edgeAB;
+            (int x, int y) = edgeXY;
+        
+            (int a, int b, int x, int dupe)? isTri = null;
+            // Do those two edge share a vertex
+            if (x == a || x == b)
+                isTri = (a, b, y, x);
+            else if (y == a || y == b)
+                isTri = (a, b, x, y);
+            
+            if (isTri.HasValue)
+            {
+                var tri = isTri.Value;
+                data.tris.Add((tri.a, tri.b, tri.x));
+                
+                var newEdge = tri.dupe == a ? new EdgeId(b, tri.x) : new EdgeId(a, tri.x);
+                
+                // Created a triangle from two existing edges, the third one formed by them must now be added to the pool to be solved for
+                if (data.allEdges.Add(newEdge))
+                    data.edgesLeft.Add(newEdge);
+                else
+                    data.edgesLeft.Remove(newEdge);
+            }
+            else
+            {
+                var vertices = data.vertices;
+                var pivot = Vector3.Dot((vertices[b] - vertices[a]).normalized, (vertices[y] - vertices[x]).normalized) >= 0 ? b : a;
+                
+                data.tris.Add((a, b, x));
+                data.tris.Add((x, pivot, y));
+
+                EdgeId newEdge0, newEdge1;
+                if (pivot == b)
+                {
+                    newEdge0 = new EdgeId(a, x);
+                    newEdge1 = new EdgeId(b, y);
+                }
+                else
+                {
+                    newEdge0 = new EdgeId(a, y);
+                    newEdge1 = new EdgeId(b, x);
+                }
+                
+                // Created a quad to bridge those two edges, two new edges were formed through this process and
+                // must now be added to the pool to be solved for.
+                if (data.allEdges.Add(newEdge0))
+                    data.edgesLeft.Add(newEdge0);
+                else            
+                    data.edgesLeft.Remove(newEdge0);
+                if (data.allEdges.Add(newEdge1))
+                    data.edgesLeft.Add(newEdge1);
+                else
+                    data.edgesLeft.Remove(newEdge1);
+            }
+        }
+        
+        static bool ReturnBestMatchFor(ref EdgeId edge, ref WorkingData data, out (float dist, EdgeId edge, Segment seg) output)
+        {
+            var vertices = data.vertices;
+            var edgesLeft = data.edgesLeft;
+            
+            // Prevents testing edge against itself on every iteration of the loop, will be added back lower
+            edgesLeft.Remove(edge);
+            
+            var seg = new Segment(vertices[edge.a], vertices[edge.b]);
+            (float dist, EdgeId edge, Segment seg) closest = (float.PositiveInfinity, default, default);
+            foreach (var otherEdge in edgesLeft)
+            {
+                var otherSeg = new Segment(vertices[otherEdge.a], vertices[otherEdge.b]);
+                ComputeScoreFor(ref seg, ref otherSeg, out var dist);
+                if (dist < closest.dist)
+                    closest = (dist, otherEdge, otherSeg);
+            }
+
+            edgesLeft.Add(edge);
+
+            output = closest;
+            return closest.dist != float.PositiveInfinity;
+        }
+
+        static void ComputeScoreFor(ref Segment segX, ref Segment segY, out float score)
+        {
+            if (segX.lengthSqr == 0f)
+            {
+                // segX is a point
+                if (segY.lengthSqr == 0f)
+                {
+                    // Both segments are points
+                    score = (segX.a - segY.a).sqrMagnitude;
+                }
+                else
+                {
+                    // segX is a point and segY a segment
+                    var aOnSegB = Vector3.Dot(segX.a - segY.a, segY.delta) / segY.lengthSqr;
+                    score = (segX.a - (segY.a + segY.delta * aOnSegB)).sqrMagnitude;
+                }
+                return;
+            }
+            else if (segY.lengthSqr == 0f)
+            {
+                // Swap segments and let recursion handle this
+                ComputeScoreFor(ref segY, ref segX, out score);
+                return;
+            }
+
+            // From here on out, both segments are guaranteed to have a length above zero
+
+            if (segX.lengthSqr > segY.lengthSqr)
+                ComputeScoreInner(ref segX, ref segY, out score);
+            else
+                ComputeScoreInner(ref segY, ref segX, out score);
+        }
+        
+        /// <summary> segX must be longer than segY, swap them if they aren't ! </summary>
+        static void ComputeScoreInner(ref Segment segX, ref Segment segY, out float score)
+        {
+            // this method operates knowing that segY is smaller than segX
+
+            // Find closest point on segmentX from both edges of segmentY
+            // ... now computing factor along segmentX
+            var fA = Vector3.Dot(segY.a - segX.a, segX.delta) / segX.lengthSqr;
+            var fB = Vector3.Dot(segY.b - segX.a, segX.delta) / segX.lengthSqr;
+            // factor may be outside [0,1], meaning that the closest point is outside of the segment along its line
+            var fCA = Mathf.Clamp01(fA);
+            var fCB = Mathf.Clamp01(fB);
+            if (fCA == fA || fCB == fB)
+            {
+                // At least one of the closest pos is on segmentX
+                // Project them both back onto segmentY and find the differences to derive a score
+                // hinting to how skewed the resulting quads/tris bridging those segments would be.
+                // This came mostly through intuition, even if this is flawed, the score is
+                // not nearly as important as validating that both segments are each other's best match.
+                
+                var aOnX = segX.a + segX.delta * fA;
+                var aBack = segY.a + segY.delta * Mathf.Clamp01(Vector3.Dot(aOnX - segY.a, segY.delta) / segY.lengthSqr);
+                var bOnX = segX.a + segX.delta * fB;
+                var bBack = segY.a + segY.delta * Mathf.Clamp01(Vector3.Dot(bOnX - segY.a, segY.delta) / segY.lengthSqr);
+                
+                // Projection to projection distance is rated lower than projection back to vertex
+                // this way edges slightly further away but parallel are preferred over those perpendicular to each other
+                score = ((aOnX - aBack).sqrMagnitude + (bOnX - bBack).sqrMagnitude) * 0.5f
+                        + (segY.a - aBack).sqrMagnitude + (segY.b - bBack).sqrMagnitude;
+                score *= 0.5f;
+            }
+            else
+            {
+                // The segments do not share a plane in common, return distance from edges
+                score = (segX.a - segY.a).sqrMagnitude +
+                        (segX.b - segY.b).sqrMagnitude;
+                score *= 0.5f;
+            }
+        }
+
+        /// <summary> Provides hooks into the stitching procedure for debug purposes </summary>
+        public interface ISolverDebugProvider
+        {
+            /// <summary>
+            /// Provides a way to hook into the data the solver is working with,
+            /// to read while the solver yields for example.
+            /// Writing to those collections will lead to undefined behaviors.
+            /// </summary>
+            void HookIntoWorkingData(WorkingData data);
+            void LogWarning(string str);
+            void Log(string str);
+        }
+
+        /// <summary> Deterministic identity for an edge </summary>
+        public readonly struct EdgeId : IEquatable<EdgeId>
+        {
+            /// <summary>
+            /// <see cref="a"/> is guaranteed to be smaller than <see cref="b"/>,
+            /// they are indices to the vertex position buffer.
+            /// </summary>
+            public readonly int a, b;
+
+            public EdgeId(int x, int y)
+            {
+                a = Min(x, y);
+                b = Max(x, y);
+            }
+
+            public void Deconstruct(out int oA, out int oB)
+            {
+                oA = a;
+                oB = b;
+            }
+
+            public static bool operator ==(EdgeId x, EdgeId y) => x.a == y.a && x.b == y.b;
+            public static bool operator !=(EdgeId x, EdgeId y) => x.a != y.a || x.b != y.b;
+
+            public bool Equals(EdgeId other) => a == other.a && b == other.b;
+            public override bool Equals(object obj) => obj is EdgeId other && Equals(other);
+            public override int GetHashCode() => (a, b).GetHashCode();
+            public override string ToString() => (a, b).ToString();
+        }
+
+        public readonly struct WorkingData
+        {
+            public readonly List<(int, int, int)> tris;
+            public readonly HashSet<EdgeId> allEdges;
+            public readonly HashSet<EdgeId> edgesLeft;
+            public readonly Vector3[] vertices;
+
+            public WorkingData(
+                List<(int, int, int)> pTris, 
+                HashSet<EdgeId> pAllEdges, 
+                HashSet<EdgeId> pEdgesLeft, 
+                Vector3[] pVertices)
+            {
+                tris = pTris;
+                allEdges = pAllEdges;
+                edgesLeft = pEdgesLeft;
+                vertices = pVertices;
+            }
+        }
+
+        readonly struct Segment
+        {
+            public readonly Vector3 a, b, delta;
+            public readonly float lengthSqr;
+
+            public Segment(Vector3 pA, Vector3 pB)
+            {
+                a = pA;
+                b = pB;
+                delta = pB - pA;
+                lengthSqr = delta.sqrMagnitude;
+            }
+        }
+
+        class AsyncJob
+        {
+            CancellationToken cancellationToken;
+            List<int>[] subMeshes;
+            Action onFinished;
+            Mesh mesh;
+
+            public void Solve(Mesh pMesh, ISolverDebugProvider debug, CancellationToken pCancellationToken, Action pOnFinished, float maxDist = 0.05f)
+            {
+                mesh = pMesh;
+                cancellationToken = pCancellationToken;
+                onFinished = pOnFinished;
+                subMeshes = new List<int>[mesh.subMeshCount];
+                for (int i = 0; i < mesh.subMeshCount; i++)
+                    subMeshes[i] = mesh.GetTriangles(i).ToList();
+
+                var tris = mesh.triangles;
+                var verts = mesh.vertices;
+                System.Threading.Tasks.Task.Run(() =>
+                {
+                    try
+                    {
+                        foreach (var _ in SolveRaw(verts, tris, subMeshes, debug, maxDist))
+                            cancellationToken.ThrowIfCancellationRequested();
+                    
+                        cancellationToken.ThrowIfCancellationRequested();
+                        EditorApplication.update += OnMainThread;
+                    }
+                    catch (Exception e) when(e is OperationCanceledException == false)
+                    {
+                        Debug.LogException(e);
+                    }
+                }, cancellationToken);
+            }
+
+            void OnMainThread()
+            {
+                EditorApplication.update -= OnMainThread;
+                if(cancellationToken.IsCancellationRequested)
+                    return;
+
+                var totalIndices = 0;
+                foreach (var list in subMeshes)
+                    totalIndices += list.Count;
+            
+                if(totalIndices > ushort.MaxValue)
+                    mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+
+                for (int i = 0; i < subMeshes.Length; i++)
+                    mesh.SetTriangles(subMeshes[i], i);
+                onFinished?.Invoke();
+            }
+        }
+    }
+}

--- a/Plugins/Editor/Scripts/Control/Helpers/CracksStitching.cs.meta
+++ b/Plugins/Editor/Scripts/Control/Helpers/CracksStitching.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c055abffbb9e5ac4faa3ff600910c0b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/Editor/Scripts/View/GUI/ComponentEditorWindows/CSGModelComponent.Inspector.GUI.cs
+++ b/Plugins/Editor/Scripts/View/GUI/ComponentEditorWindows/CSGModelComponent.Inspector.GUI.cs
@@ -212,6 +212,7 @@ namespace RealtimeCSG
             bool?	DoNotRender				= (Settings & ModelSettingsFlags.DoNotRender) == ModelSettingsFlags.DoNotRender;
             bool?	TwoSidedShadows			= (Settings & ModelSettingsFlags.TwoSidedShadows) == ModelSettingsFlags.TwoSidedShadows;
 //			bool?	ReceiveShadows			= !((settings & ModelSettingsFlags.DoNotReceiveShadows) == ModelSettingsFlags.DoNotReceiveShadows);
+            bool?	AutoStitchCracks        = (Settings & ModelSettingsFlags.AutoStitchCracks) == ModelSettingsFlags.AutoStitchCracks;
             bool?	AutoRebuildUVs          = (Settings & ModelSettingsFlags.AutoRebuildUVs) == ModelSettingsFlags.AutoRebuildUVs;
             bool?	PreserveUVs             = (Settings & ModelSettingsFlags.PreserveUVs) == ModelSettingsFlags.PreserveUVs;
             bool?	StitchLightmapSeams     = (Settings & ModelSettingsFlags.StitchLightmapSeams) == ModelSettingsFlags.StitchLightmapSeams;
@@ -266,6 +267,7 @@ namespace RealtimeCSG
                 bool	currDoNotRender				= (Settings & ModelSettingsFlags.DoNotRender) == ModelSettingsFlags.DoNotRender;
                 bool	currTwoSidedShadows			= (Settings & ModelSettingsFlags.TwoSidedShadows) == ModelSettingsFlags.TwoSidedShadows;
 //				bool	currReceiveShadows			= !((settings & ModelSettingsFlags.DoNotReceiveShadows) == ModelSettingsFlags.DoNotReceiveShadows);
+                bool	currAutoStitchCracks		= (Settings & ModelSettingsFlags.AutoStitchCracks) == ModelSettingsFlags.AutoStitchCracks;
                 bool	currAutoRebuildUVs			= (Settings & ModelSettingsFlags.AutoRebuildUVs) == ModelSettingsFlags.AutoRebuildUVs;
                 bool	currPreserveUVs				= (Settings & ModelSettingsFlags.PreserveUVs) == ModelSettingsFlags.PreserveUVs;
                 bool	currStitchLightmapSeams		= (Settings & ModelSettingsFlags.StitchLightmapSeams) == ModelSettingsFlags.StitchLightmapSeams;
@@ -303,6 +305,7 @@ namespace RealtimeCSG
                 if (TwoSidedShadows			.HasValue && TwoSidedShadows		.Value != currTwoSidedShadows		) TwoSidedShadows = null;
 //				if (ReceiveShadows			.HasValue && ReceiveShadows			.Value != currReceiveShadows		) ReceiveShadows = null;
 //				if (ShadowCastingMode		.HasValue && ShadowCastingMode		.Value != currShadowCastingMode		) ShadowCastingMode = null;
+                if (AutoStitchCracks     	.HasValue && AutoStitchCracks     	.Value != currAutoStitchCracks		) AutoStitchCracks = null;
                 if (AutoRebuildUVs     		.HasValue && AutoRebuildUVs     	.Value != currAutoRebuildUVs		) AutoRebuildUVs = null;
                 if (PreserveUVs     		.HasValue && PreserveUVs     		.Value != currPreserveUVs	    	) PreserveUVs = null;
                 if (StitchLightmapSeams		.HasValue && StitchLightmapSeams	.Value != currStitchLightmapSeams	) StitchLightmapSeams = null;
@@ -1129,6 +1132,27 @@ namespace RealtimeCSG
                             // Workaround for unity not refreshing the hierarchy when changing hideflags
                             EditorApplication.RepaintHierarchyWindow();
                             EditorApplication.DirtyHierarchyWindowSorting();
+                        }
+                        {
+                            var autoStitchCracks = AutoStitchCracks ?? false;
+                            EditorGUI.BeginChangeCheck();
+                            {
+                                EditorGUI.showMixedValue = !AutoStitchCracks.HasValue;
+                                autoStitchCracks = EditorGUILayout.Toggle(StitchCracksContent, autoStitchCracks);
+                            }
+                            if (EditorGUI.EndChangeCheck())
+                            {
+                                for (int i = 0; i < models.Length; i++)
+                                {
+                                    if (autoStitchCracks)
+                                        models[i].Settings |= ModelSettingsFlags.AutoStitchCracks;
+                                    else
+                                        models[i].Settings &= ~ModelSettingsFlags.AutoStitchCracks;
+                                    MeshInstanceManager.Refresh(models[i], onlyFastRefreshes: false);
+                                }
+                                GUI.changed = true;
+                                AutoStitchCracks = autoStitchCracks;
+                            }
                         }
 
 #if UNITY_2017_3_OR_NEWER

--- a/Plugins/Editor/Scripts/View/GUI/ComponentEditorWindows/CSGModelComponent.Inspector.GUIContents.cs
+++ b/Plugins/Editor/Scripts/View/GUI/ComponentEditorWindows/CSGModelComponent.Inspector.GUIContents.cs
@@ -67,6 +67,8 @@ namespace RealtimeCSG
 
 		private static readonly GUIContent MinimumChartSizeContent				= new GUIContent("Min Chart Size", "Specifies the minimum texel size used for a UV chart. If stitching is required, a value of 4 will create a chart of 4x4 texels to store lighting and directionality. If stitching is not required, a value of 2 will reduce the texel density and provide better lighting build times and run time performance.");
 
+		private static readonly GUIContent StitchCracksContent					= new GUIContent("Stitch Cracks", "Fill in cracks that came out through the mesh generation process, increases the amount of triangles.");
+		
 		public static int[] MinimumChartSizeValues = { 2, 4 };
 		public static GUIContent[] MinimumChartSizeStrings =
 		{

--- a/Plugins/Runtime/Scripts/Components/GeneratedMeshInstance.cs
+++ b/Plugins/Runtime/Scripts/Components/GeneratedMeshInstance.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
 using UnityEngine;
 using UnityEngine.Serialization;
 using MeshQuery = RealtimeCSG.Foundation.MeshQuery;
@@ -130,10 +131,14 @@ namespace InternalRealtimeCSG
 
 		[HideInInspector] public bool   HasGeneratedNormals = false;
 		[HideInInspector] public bool	HasUV2				= false;
+		[HideInInspector] public bool	HasNoCracks			= false;
         [NonSerialized]
 		[HideInInspector] public float	ResetUVTime			= float.PositiveInfinity;
+        [HideInInspector] public float  ResetStitchCracksTime = float.PositiveInfinity;
 		[HideInInspector] public Int64	LightingHashValue;
-
+		[HideInInspector] public Int64  CracksHashValue;
+		
+		[NonSerialized] public CancellationTokenSource CracksSolverCancellation;
 		[NonSerialized] [HideInInspector] public bool Dirty	= true;
 		[NonSerialized] [HideInInspector] public MeshCollider	CachedMeshCollider;
 		[NonSerialized] [HideInInspector] public MeshFilter		CachedMeshFilter;
@@ -149,7 +154,10 @@ namespace InternalRealtimeCSG
 		    HasGeneratedNormals     = false;
 		    HasUV2				    = false;
             ResetUVTime			    = float.PositiveInfinity;
+            ResetStitchCracksTime   = float.PositiveInfinity;
 		    LightingHashValue       = 0;
+		    CracksHashValue         = 0;
+		    CracksSolverCancellation?.Cancel();
 
 		    Dirty	                = true;
 

--- a/Plugins/Runtime/Scripts/Components/GeneratedMeshInstance.cs
+++ b/Plugins/Runtime/Scripts/Components/GeneratedMeshInstance.cs
@@ -132,9 +132,9 @@ namespace InternalRealtimeCSG
 		[HideInInspector] public bool   HasGeneratedNormals = false;
 		[HideInInspector] public bool	HasUV2				= false;
 		[HideInInspector] public bool	HasNoCracks			= false;
-        [NonSerialized]
+		[NonSerialized]
 		[HideInInspector] public float	ResetUVTime			= float.PositiveInfinity;
-        [HideInInspector] public float  ResetStitchCracksTime = float.PositiveInfinity;
+		[HideInInspector] public float  ResetStitchCracksTime = float.PositiveInfinity;
 		[HideInInspector] public Int64	LightingHashValue;
 		[HideInInspector] public Int64  CracksHashValue;
 		
@@ -150,11 +150,11 @@ namespace InternalRealtimeCSG
 		    RenderMaterial          = null;
 		    PhysicsMaterial         = null;
 		    RenderSurfaceType       = (RenderSurfaceType)999;
-        
+		
 		    HasGeneratedNormals     = false;
 		    HasUV2				    = false;
-            ResetUVTime			    = float.PositiveInfinity;
-            ResetStitchCracksTime   = float.PositiveInfinity;
+		    ResetUVTime			    = float.PositiveInfinity;
+		    ResetStitchCracksTime   = float.PositiveInfinity;
 		    LightingHashValue       = 0;
 		    CracksHashValue         = 0;
 		    CracksSolverCancellation?.Cancel();

--- a/Plugins/Runtime/Scripts/Components/GeneratedMeshInstance.cs
+++ b/Plugins/Runtime/Scripts/Components/GeneratedMeshInstance.cs
@@ -138,7 +138,7 @@ namespace InternalRealtimeCSG
 		[HideInInspector] public Int64	LightingHashValue;
 		[HideInInspector] public Int64  CracksHashValue;
 		
-		[NonSerialized] public CancellationTokenSource CracksSolverCancellation;
+		[NonSerialized] public Action CracksSolverCancellation;
 		[NonSerialized] [HideInInspector] public bool Dirty	= true;
 		[NonSerialized] [HideInInspector] public MeshCollider	CachedMeshCollider;
 		[NonSerialized] [HideInInspector] public MeshFilter		CachedMeshFilter;
@@ -157,7 +157,7 @@ namespace InternalRealtimeCSG
 		    ResetStitchCracksTime   = float.PositiveInfinity;
 		    LightingHashValue       = 0;
 		    CracksHashValue         = 0;
-		    CracksSolverCancellation?.Cancel();
+		    CracksSolverCancellation?.Invoke();
 
 		    Dirty	                = true;
 


### PR DESCRIPTION
# Crack Stitching
Introduces a toggle to the model inspector UI which, once toggled on, fixes cracks appearing through generated geometry. It does so asynchronously to prevent interrupting the user while he's working.

See [discussion on discord](https://discord.com/channels/531067645433348106/531080244472315965/1048040793526517820) for further information.

## Inspector
![image](https://user-images.githubusercontent.com/5742236/206205550-a6952d16-1e59-481f-96c6-0a259d87d290.png)
## Result
![image](https://user-images.githubusercontent.com/5742236/206205435-0aeff616-dd96-4aa7-93ee-e00d3a3bd72e.png)
![image](https://user-images.githubusercontent.com/5742236/206474797-27eee400-1cb9-4f36-ad8b-3a1bafc9cb85.png)

Here's a more advanced implementation of the debugger interface if someone wants to debug this in the future: 
[StitchingDebugger.zip](https://github.com/LogicalError/realtime-CSG-for-unity/files/10187950/StitchingDebugger.zip)
Don't forget to comment out `#define YIELD_SUBSTEPS` above `CracksStitching.cs`