### PR TITLE
Mouse Cursor Issue solving

### DIFF
--- a/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/EditMode.Place.cs
+++ b/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/EditMode.Place.cs
@@ -1119,14 +1119,7 @@ namespace RealtimeCSG
 		MouseCursor currentCursor = MouseCursor.Arrow;
 		void UpdateMouseCursor()
 		{
-			switch (SelectionUtility.GetEventSelectionType())
-			{
-				case SelectionType.Additive:	currentCursor = MouseCursor.ArrowPlus; break;
-				case SelectionType.Subtractive: currentCursor = MouseCursor.ArrowMinus; break;
-				case SelectionType.Toggle:		currentCursor = MouseCursor.Arrow; break;
-
-				default:						currentCursor = MouseCursor.Arrow; break;
-			}
+			currentCursor = CursorUtility.GetSelectionCursor(SelectionUtility.GetEventSelectionType());
 		}
 
 		[NonSerialized] bool ignorePivotChange = false;
@@ -1359,10 +1352,9 @@ namespace RealtimeCSG
 			var inCamera			= (camera != null) && camera.pixelRect.Contains(Event.current.mousePosition);
 
 			var originalEventType = Event.current.type;
-            if( Event.current.type == EventType.MouseMove ) { sceneView.Repaint(); }
-            else if      (originalEventType == EventType.MouseMove) { mouseIsDragging = false; draggingOnCamera = null; realMousePosition   = Event.current.mousePosition; }
-            else if (originalEventType == EventType.MouseDown) { mouseIsDragging      = false; draggingOnCamera = camera; realMousePosition = prevMousePos = Event.current.mousePosition; }
-			else if (originalEventType == EventType.MouseUp)   { draggingOnCamera     = null; }
+			if		(originalEventType == EventType.MouseMove) { mouseIsDragging	= false; draggingOnCamera = null; realMousePosition   = Event.current.mousePosition; }
+			else if (originalEventType == EventType.MouseDown) { mouseIsDragging	= false; draggingOnCamera = camera; realMousePosition = prevMousePos = Event.current.mousePosition; }
+			else if (originalEventType == EventType.MouseUp)   { draggingOnCamera	= null; }
 			else if (originalEventType == EventType.MouseDrag)
 			{
 				if (!mouseIsDragging && (prevMousePos - Event.current.mousePosition).magnitude > 4.0f)
@@ -1393,13 +1385,18 @@ namespace RealtimeCSG
 				{
 					if (!SceneDragToolManager.IsDraggingObjectInScene)
 					{
-                        {
-                            if (sceneView)
-                            {
-                                var windowRect = new Rect(0, 0, sceneView.position.width, sceneView.position.height - CSG_GUIStyleUtility.BottomToolBarHeight);
-                                EditorGUIUtility.AddCursorRect(windowRect, currentCursor);
-                            }
-                        }
+						if (sceneView)
+						{
+#if UNITY_2020_2_OR_NEWER
+							if (!Tools.viewToolActive)
+#else
+							if (Tools.current != Tool.View && !Event.current.alt && Event.current.button != 1 && Event.current.button != 2)
+#endif
+							{
+								var windowRect = new Rect(0, 0, sceneView.position.width, sceneView.position.height - CSG_GUIStyleUtility.BottomToolBarHeight);
+								EditorGUIUtility.AddCursorRect(windowRect, currentCursor);
+							}
+						}
 
 						if (!mouseIsDragging &&
 							(toolEditMode == ToolEditMode.MovingObject ||

--- a/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/EditMode.Surface.cs
+++ b/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/EditMode.Surface.cs
@@ -470,22 +470,15 @@ namespace RealtimeCSG
             hoverOnSurfaceIndex = index;
             return editModeType;
         }
-                
-        MouseCursor currentCursor = MouseCursor.Arrow;
-        void UpdateMouseCursor()
-        {
-            if (mouseIsDown)
-                return;
-            
-            switch (SelectionUtility.GetEventSelectionType())
-            {
-                case SelectionType.Additive:	currentCursor = MouseCursor.ArrowPlus; break;
-                case SelectionType.Subtractive: currentCursor = MouseCursor.ArrowMinus; break;
-                case SelectionType.Toggle:		currentCursor = MouseCursor.Arrow; break;
 
-                default:						currentCursor = MouseCursor.Arrow; break;
-            }
-        }
+		MouseCursor currentCursor = MouseCursor.Arrow;
+		void UpdateMouseCursor()
+		{
+			if (mouseIsDown)
+				return;
+
+			currentCursor = CursorUtility.GetSelectionCursor(SelectionUtility.GetEventSelectionType());
+		}
 
         bool UpdateGrid(Camera camera)
         {
@@ -1132,10 +1125,16 @@ namespace RealtimeCSG
                     
                         if (sceneView != null)
                         {
-                            var windowRect = new Rect(0, 0, sceneView.position.width, sceneView.position.height - CSG_GUIStyleUtility.BottomToolBarHeight);
-                            if (currentCursor != MouseCursor.Arrow)
-                                EditorGUIUtility.AddCursorRect(windowRect, currentCursor);
-                        }
+#if UNITY_2020_2_OR_NEWER
+							if (!Tools.viewToolActive)
+#else
+							if (Tools.current != Tool.View && !Event.current.alt && Event.current.button != 1 && Event.current.button != 2)
+#endif
+							{
+								var windowRect = new Rect(0, 0, sceneView.position.width, sceneView.position.height - CSG_GUIStyleUtility.BottomToolBarHeight);
+								if (currentCursor != MouseCursor.Arrow) EditorGUIUtility.AddCursorRect(windowRect, currentCursor);
+							}
+						}
                         
                         if (currentControl == -1 ||
                             currentControl == surfaceSelectPaintControl)
@@ -1339,14 +1338,12 @@ namespace RealtimeCSG
                                     }
                                 }					
                             }
+                            if (!repaint)
                             {
-                                if (!repaint)
+                                for (int p = 0; p < surfaceState.surfaceSelectState.Length; p++)
                                 {
-                                    for (int p = 0; p < surfaceState.surfaceSelectState.Length; p++)
-                                    {
-                                        if (surfaceState.surfaceSelectState[p] != oldSurfaceStates[p] || oldSurfaceStates[p] == SelectState.None)
-                                            repaint = true;
-                                    }
+                                    if (surfaceState.surfaceSelectState[p] != oldSurfaceStates[p] || oldSurfaceStates[p] == SelectState.None)
+                                        repaint = true;
                                 }
                             }
                         }


### PR DESCRIPTION
Minor changes aimed at fixing Mouse Cursor Display issues.
1- Prevents the buggy cursor flickering in 2021.3 when using the pan view tool or moving around in sceneview. Only cases where this still happens is when the pan view tool is selected and the user hovers the mouse next to the edge of a re-sizable docked window (im pretty certain this is a Unity bug since it happens without rcsg installed).

2- Solves the viewtool cursors never appearing in 2019.4 when in Place/Edit/Surface mode. Only thing that doesn't work is MMB shortcut for view pan swapping the cursor to the grab hand, I cant understand why right now, I imagine it'll be more obvious after further cleaning and refactoring of the EditModes code.

These changes have been tested on 2021.3.16f1, 2020.3.37f1 and 2019.4.40f1