### PR TITLE
fix: Brush selection in 2023.x being bypassed by unity's own scene picking

### DIFF
--- a/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/EditMode.Place.cs
+++ b/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/EditMode.Place.cs
@@ -1843,6 +1843,8 @@ namespace RealtimeCSG
 								hoverOnBoundsEdge != -1)*/
 							{
 								SelectionUtility.DoSelectionClick(sceneView);
+								// We're doing manual selection, make sure to eat the event otherwise unity will run its own MouseUp for selection logic
+								Event.current.Use();
 							}
 						}
 						mouseIsDragging = false;


### PR DESCRIPTION
# PR Details
In Unity 2023, scene picking fails to select brushes as unity runs its own scene picking after RCSG sets the selection;

![iqElMchOAU](https://github.com/user-attachments/assets/d6110b04-eb47-4032-ac9b-7de2017407f3)

This PR ensures unity doesn't run their logic by eating the mouse down GUI event, similar to how the other branches in that very switch operate.