### PR TITLE
fix: Mouse look when using FreeDraw

### DIFF
--- a/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/Generators/Generator.FreeDraw.cs
+++ b/Plugins/Editor/Scripts/View/GUI/EditModeGUI/EditModes/Generators/Generator.FreeDraw.cs
@@ -1153,10 +1153,12 @@ namespace RealtimeCSG
 				case EventType.MouseDrag:
 				{
 					clickCount = 0;
-					if (GUIUtility.hotControl != base.shapeId)
-						return;
-
-					Event.current.Use();
+					if (Tools.viewTool != ViewTool.None && Tools.viewTool != ViewTool.Pan)
+						break;
+					if (GUIUtility.hotControl == base.shapeId && Event.current.button == 0)
+					{
+						Event.current.Use();
+					}
 					return;
 				}
 				case EventType.MouseUp:


### PR DESCRIPTION
Holding right click when using freedraw does not rotate the view, this PR fixes that.
The changes introduced are lifted from the Generator.Box implementation of the same logic.